### PR TITLE
Existence check

### DIFF
--- a/gapless5.js
+++ b/gapless5.js
@@ -304,9 +304,13 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
  			// not using audio.networkState because it's not dependable on all browsers
 		}
 		// cancel if url doesn't exist
-		$.get(inAudioPath).fail(function() { 
-	        that.cancelRequest(true);
-	    })
+                // cancel if url doesn't exist, but don't download again
+                $.ajax({
+                        url: inAudioPath,
+                        type: "HEAD",
+                }).fail(function() { 
+                        that.cancelRequest(true);
+                });
 	}
 }
 

--- a/gapless5.js
+++ b/gapless5.js
@@ -303,7 +303,6 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 	 		audio.addEventListener('play', onPlayEvent, false);
  			// not using audio.networkState because it's not dependable on all browsers
 		}
-		// cancel if url doesn't exist
                 // cancel if url doesn't exist, but don't download again
                 $.ajax({
                         url: inAudioPath,


### PR DESCRIPTION
Currently Gapless downloads 3 copies of a song for each request. One of them is a $.get check for detecting whether the file exists. I changed this to a $.ajax with type: HEAD, so that it doesn't pull the whole song to detect whether it exists.

In the case of a missing song the error state details should behave the same way.