### PR TITLE
fix gotoTrack after removeAllTracks, don't use sources[oi].audioPath

### DIFF
--- a/gapless5.js
+++ b/gapless5.js
@@ -681,7 +681,7 @@ this.gotoTrack = function (newIndex, bForcePlay) {
 		if (sources[oldIndex].getState() == Gapless5State.Loading)
 		{
 			sources[oldIndex].cancelRequest();
-			that.loadQueue.push([oldIndex, sources[oldIndex].audioPath]);
+			that.loadQueue.push([oldIndex, that.tracks[oldIndex]]);
 		}
 
 		resetPosition(true); // make sure this comes after trackIndex has been updated


### PR DESCRIPTION
Gapless tries to load an "undefined" track if you do a gotoTrack after resetAllTracks(). This is fixed by grabbing the audioPath not from the sources object, but from the tracks array in the player object.

I'm testing this on my internal gapless jukeboxes and it appears to work without issues, but any brain/eyes behind making sure this change does the right thing is appreciated :)