### PR TITLE
Request manager

### DIFF
--- a/gapless5.js
+++ b/gapless5.js
@@ -364,16 +364,16 @@ var Gapless5RequestManager = function() {
 		if (that.loadQueue.length > 0)
 		{
 			var entry = that.loadQueue.shift();
-			loadingTrack = entry[0];
-			if (loadingTrack < sources.length)
+			that.loadingTrack = entry[0];
+			if (that.loadingTrack < sources.length)
 			{
-				//console.log("loading track " + loadingTrack + ": " + entry[1]);
-				sources[loadingTrack].load(entry[1]);
+				//console.log("loading track " + that.loadingTrack + ": " + entry[1]);
+				sources[that.loadingTrack].load(entry[1]);
 			}
 		}
 		else
 		{
-			loadingTrack = -1;
+			that.loadingTrack = -1;
 		}
 	}
 }

--- a/gapless5.js
+++ b/gapless5.js
@@ -122,7 +122,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		{
 			loadMS = (new Date().getTime()) - initMS;
 			// TODO: where does sources live!?
-			parent.manager.dequeueNextLoad(parent.sources);
+			parent.mgr.dequeueNextLoad(parent.sources);
 		}
 
 		if (queuedState == Gapless5State.Play && state == Gapless5State.Loading)
@@ -150,7 +150,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		if (buffer != null || !parent.useWebAudio)
 		{
 			loadMS = (new Date().getTime()) - initMS;
-			parent.manager.dequeueNextLoad(parent.sources);
+			parent.mgr.dequeueNextLoad(parent.sources);
 		}
 
 		state = Gapless5State.Stop;
@@ -760,7 +760,7 @@ var sources = [];	// Loaded as audio files
 this.tracks = null;	// Playlist manager object
 
 // Request manager for loading songs
-this.manager = new Gapless5RequestManager();
+this.mgr = new Gapless5RequestManager();
 
 // Callback and Execution logic
 var inCallback = false;
@@ -1001,10 +1001,10 @@ this.onFinishedScrubbing = function () {
 this.addInitialTrack = function(audioPath) {
 	var next = sources.length;
 	sources[next] = new Gapless5Source(this, context, gainNode);
-	that.manager.loadQueue.push([next, audioPath]);
-	if (that.manager.loadingTrack == -1)
+	that.mgr.loadQueue.push([next, audioPath]);
+	if (that.mgr.loadingTrack == -1)
 	{
-		that.manager.dequeueNextLoad(sources);
+		that.mgr.dequeueNextLoad(sources);
 	}
 	if (initialized)
 	{
@@ -1017,10 +1017,10 @@ this.addTrack = function (audioPath) {
 	sources[next] = new Gapless5Source(this, context, gainNode);
 	// TODO: refactor to take an entire JSON object
 	that.tracks.add(next, audioPath);
-	that.manager.loadQueue.push([next, audioPath]);
-	if (that.manager.loadingTrack == -1)
+	that.mgr.loadQueue.push([next, audioPath]);
+	if (that.mgr.loadingTrack == -1)
 	{
-		that.manager.dequeueNextLoad(sources);
+		that.mgr.dequeueNextLoad(sources);
 	}
 	if (initialized)
 	{
@@ -1042,15 +1042,15 @@ this.insertTrack = function (point, audioPath) {
 		// TODO: refactor to take an entire JSON object
 		that.tracks.add(point, audioPath);
 		//re-enumerate queue
-		for (var i in that.manager.loadQueue)
+		for (var i in that.mgr.loadQueue)
 		{
-			var entry = that.manager.loadQueue[i];
+			var entry = that.mgr.loadQueue[i];
 			if (entry[0] >= point)
 			{
 				entry[0] += 1;
 			}
 		}
-		that.manager.loadQueue.splice(0,0,[point,audioPath]);
+		that.mgr.loadQueue.splice(0,0,[point,audioPath]);
 		updateDisplay();
 	}
 };
@@ -1072,9 +1072,9 @@ this.removeTrack = function (point) {
 	}
 	
 	var removeIndex = -1;
-	for (var i in that.manager.loadQueue)
+	for (var i in that.mgr.loadQueue)
 	{
-		var entry = that.manager.loadQueue[i];
+		var entry = that.mgr.loadQueue[i];
 		if (entry[0] == point)
 		{
 			removeIndex = i;
@@ -1086,14 +1086,14 @@ this.removeTrack = function (point) {
 	}
 	if (removeIndex >= 0)
 	{
-		that.manager.loadQueue.splice(removeIndex,1);
+		that.mgr.loadQueue.splice(removeIndex,1);
 	}
 	sources.splice(point,1);
 	that.tracks.remove(point);
 
-	if (that.manager.loadingTrack == point)
+	if (that.mgr.loadingTrack == point)
 	{
-		that.manager.dequeueNextLoad(sources);
+		that.mgr.dequeueNextLoad(sources);
 	}
 	if ( point == that.tracks.currentItem )
 	{
@@ -1122,9 +1122,9 @@ this.removeAllTracks = function () {
 		}
 		sources[i].stop();
 	}
-	that.manager.loadingTrack = -1;
+	that.mgr.loadingTrack = -1;
 	sources = [];
-	that.manager.loadQueue = [];
+	that.mgr.loadQueue = [];
 	if (initialized)
 	{
 		updateDisplay();
@@ -1186,7 +1186,7 @@ this.gotoTrack = function (newIndex, bForcePlay) {
 		{
 			sources[oldIndex].cancelRequest();
 			// TODO: better way to have just the file list?
-			that.manager.loadQueue.push([oldIndex, that.tracks.files()[oldIndex]]);
+			that.mgr.loadQueue.push([oldIndex, that.tracks.files()[oldIndex]]);
 		}
 
 		resetPosition(true); // make sure this comes after currentIndex has been updated
@@ -1196,14 +1196,14 @@ this.gotoTrack = function (newIndex, bForcePlay) {
 			sources[newIndex].load(that.tracks.files()[newIndex]);
 
 			//re-sort queue so that this track is at the head of the list
-			for (var i in that.manager.loadQueue)
+			for (var i in that.mgr.loadQueue)
 			{
-				var entry = that.manager.loadQueue.shift();
+				var entry = that.mgr.loadQueue.shift();
 				if (entry[0] == newIndex)
 				{
 					break;
 				}
-				that.manager.loadQueue.push(entry);
+				that.mgr.loadQueue.push(entry);
 			}
 		}
 		updateDisplay();
@@ -1592,9 +1592,6 @@ var Init = function(elem_id, options, tickMS) {
 				that.addInitialTrack(that.tracks.files()[i]);
 		}
 	}
-
-	// Initialize the request manager 
-	// TODO
 
 	initialized = true;
 	updateDisplay();

--- a/gapless5.js
+++ b/gapless5.js
@@ -1,4 +1,4 @@
-/////////////
+////////////
 //
 // Gapless 5: Gapless JavaScript/CSS audio player for HTML5
 // (requires jQuery 1.x or greater)
@@ -393,7 +393,7 @@ var Gapless5RequestManager = function(parentPlayer) {
 		{
 			var entry = that.loadQueue.shift();
 			that.loadingTrack = entry[0];
-			if (that.loadingTrack < sources.length)
+			if (that.loadingTrack < parent.trk.sources.length)
 			{
 				//console.log("oomPolicy: loading track " + that.loadingTrack + ": " + entry[1]);
 				parent.trk.sources[that.loadingTrack].load(entry[1]);
@@ -816,7 +816,7 @@ if (context && gainNode)
 this.trk = null;	// Playlist manager object
 
 // Request manager for loading songs
-this.mgr = new Gapless5RequestManager();
+this.mgr = new Gapless5RequestManager(this);
 
 // Callback and Execution logic
 var inCallback = false;
@@ -840,7 +840,7 @@ this.onfinishedall = null;
 
 
 // INTERNAL HELPERS
-var dispTrk() = function() {
+var dispTrk = function() {
 	return that.trk.sources[dispIndex()];
 };
 

--- a/gapless5.js
+++ b/gapless5.js
@@ -343,27 +343,12 @@ var Gapless5RequestManager = function(orderedPolicy, shuffledPolicy) {
 	this.orderedPolicy = orderedPolicy;
 	this.shuffledPolicy = shuffledPolicy;
 	
-	// Stack of songs to load. 
-	// TODO: if song is added to stack that already exists in the history,
-	// grab it from there instead of downloading it again
-	var stack = [];
-	var history = []; 
-
 	// PRIVATE METHODS
 	// Choose the effective policy in use. Some rules:
 	//    album: revert to "desktop" policy if used for shuffledPolicy
         function effectivePolicy() {
 		return;
 	}
-
-	// PUBLIC METHODS
-	// Add a song to the request manager stack. 
-	// Do this just after Method returns a Gapless5Source object, so it 
-	// can be compatible with the new Gapless5Source statements.
-	this.register = function(song) {
-		return song;
-	}
-
 }
 
 

--- a/gapless5.js
+++ b/gapless5.js
@@ -415,7 +415,7 @@ var Gapless5RequestManager = function(parentPlayer) {
 	}
 
 	this.getPolicy = function() {
-		if (parent.tracks.shuffled() == true)
+		if (parent.trk.shuffled() == true)
 		{
 			return shuffledPolicy;
 		}
@@ -810,8 +810,7 @@ if (context && gainNode)
 }
 
 // Playlist
-var sources = [];	// Loaded as audio files
-this.tracks = null;	// Playlist manager object
+this.trk = null;	// Playlist manager object
 
 // Request manager for loading songs
 this.mgr = new Gapless5RequestManager();
@@ -849,8 +848,8 @@ var getSoundPos = function (uiPosition) {
 
 var numTracks = function () {
 	// FileList object must be initiated
-	if ( that.tracks != null )
-		return that.tracks.current.length;
+	if ( that.trk != null )
+		return that.trk.current.length;
 	else
 		return 0;
 };
@@ -858,8 +857,8 @@ var numTracks = function () {
 // Index for calculating actual playlist location
 var index = function () {
 	// FileList object must be initiated
-	if ( that.tracks != null )
-		return that.tracks.get();
+	if ( that.trk != null )
+		return that.trk.get();
 	else
 		return -1;
 };
@@ -868,17 +867,17 @@ var index = function () {
 // track, suitable for use in update functions
 var dispIndex = function () {
 	if ( readyToRemake() )
-		return that.tracks.previousItem;
-	else if ( that.tracks != null )
-		return that.tracks.get();
+		return that.trk.previousItem;
+	else if ( that.trk != null )
+		return that.trk.get();
 	else
 		return -1;
 }
 
 var readyToRemake = function () {
 	// FileList object must be initiated
-	if ( that.tracks.readyToRemake() != null )
-		return that.tracks.readyToRemake();
+	if ( that.trk.readyToRemake() != null )
+		return that.trk.readyToRemake();
 	else
 		return false;
 };
@@ -930,11 +929,11 @@ var refreshTracks = function(newIndex) {
 	initialized = false;
 
 	that.removeAllTracks();
-	that.tracks.rebasePlayList(newIndex);
+	that.trk.rebasePlayList(newIndex);
 
 	for (var i = 0; i < numTracks() ; i++ )
 	{
-		that.addInitialTrack(that.tracks.files()[i]);
+		that.addInitialTrack(that.trk.files()[i]);
 	}
 
 	// re-enable GUI updates
@@ -1070,7 +1069,7 @@ this.addTrack = function (audioPath) {
 	var next = sources.length;
 	sources[next] = new Gapless5Source(this, context, gainNode);
 	// TODO: refactor to take an entire JSON object
-	that.tracks.add(next, audioPath);
+	that.trk.add(next, audioPath);
 	that.mgr.loadQueue.push([next, audioPath]);
 	if (that.mgr.loadingTrack == -1)
 	{
@@ -1094,7 +1093,7 @@ this.insertTrack = function (point, audioPath) {
 		var oldPoint = point+1;
 		sources.splice(point, 0, new Gapless5Source(this, context, gainNode));
 		// TODO: refactor to take an entire JSON object
-		that.tracks.add(point, audioPath);
+		that.trk.add(point, audioPath);
 		//re-enumerate queue
 		for (var i in that.mgr.loadQueue)
 		{
@@ -1143,13 +1142,13 @@ this.removeTrack = function (point) {
 		that.mgr.loadQueue.splice(removeIndex,1);
 	}
 	sources.splice(point,1);
-	that.tracks.remove(point);
+	that.trk.remove(point);
 
 	if (that.mgr.loadingTrack == point)
 	{
 		that.mgr.dequeueNextLoad(sources);
 	}
-	if ( point == that.tracks.currentItem )
+	if ( point == that.trk.currentItem )
 	{
 		that.next();	// Don't stop after a delete
 		if ( wasPlaying )
@@ -1188,7 +1187,7 @@ this.removeAllTracks = function () {
 this.shuffleToggle = function() {
 	if (isShuffleActive == false) return;
 
-	that.tracks.shuffleToggle();
+	that.trk.shuffleToggle();
 
 	if (initialized)
 	{
@@ -1223,8 +1222,8 @@ this.gotoTrack = function (newIndex, bForcePlay) {
 
 	// A shuffle or an unshuffle just occurred
 	else if ( justRemade == true ) {
-		that.tracks.set(newIndex);
-		sources[newIndex].load(that.tracks.files()[newIndex]);
+		that.trk.set(newIndex);
+		sources[newIndex].load(that.trk.files()[newIndex]);
 		sources[newIndex].play();
 
 		updateDisplay();
@@ -1234,20 +1233,20 @@ this.gotoTrack = function (newIndex, bForcePlay) {
 	else
 	{
 		var oldIndex = index();
-	        that.tracks.set(newIndex);
+	        that.trk.set(newIndex);
 		// Cancel any track that's in loading state right now
 		if (sources[oldIndex].getState() == Gapless5State.Loading)
 		{
 			sources[oldIndex].cancelRequest();
 			// TODO: better way to have just the file list?
-			that.mgr.loadQueue.push([oldIndex, that.tracks.files()[oldIndex]]);
+			that.mgr.loadQueue.push([oldIndex, that.trk.files()[oldIndex]]);
 		}
 
 		resetPosition(true); // make sure this comes after currentIndex has been updated
 		if (sources[newIndex].getState() == Gapless5State.None)
 		{
 			// TODO: better way to have just the file list?
-			sources[newIndex].load(that.tracks.files()[newIndex]);
+			sources[newIndex].load(that.trk.files()[newIndex]);
 
 			//re-sort queue so that this track is at the head of the list
 			for (var i in that.mgr.loadQueue)
@@ -1435,8 +1434,8 @@ var updateDisplay = function () {
 	}
 	else
 	{
-		$("#trackIndex" + that.id).html(that.tracks.trackNumber);
-		$("#tracks" + that.id).html(that.tracks.current.length);
+		$("#trackIndex" + that.id).html(that.trk.trackNumber);
+		$("#tracks" + that.id).html(that.trk.current.length);
 		$("#totalPosition" + that.id).html(getTotalPositionText());
 		enableButton('prev', that.loop || index() > 0 || sources[index()].getPosition() > 0);
 		enableButton('next', that.loop || index() < numTracks() - 1);
@@ -1459,10 +1458,10 @@ var updateDisplay = function () {
 
 		// Must have at least 3 tracks in order for shuffle button to work
 		// If so, permanently turn on the shuffle toggle
-		if (that.tracks.current.length > 2)
+		if (that.trk.current.length > 2)
 			isShuffleActive = true;
 
-		if (that.tracks.shuffled())
+		if (that.trk.shuffled())
 			shuffleButton('unshuffle', isShuffleActive);
 		else
 			shuffleButton('shuffle', isShuffleActive);
@@ -1623,8 +1622,8 @@ var Init = function(elem_id, options, tickMS) {
 			// shuffle mode doesn't make sense here.
 			var items = [{}];
 			items[0].file = options.tracks;
-			that.tracks = new Gapless5FileList(items, 0, false);
-			that.addInitialTrack(that.tracks.files()[0]);
+			that.trk = new Gapless5FileList(items, 0, false);
+			that.addInitialTrack(that.trk.files()[0]);
 		}
 		else if (typeof options.tracks[0] == 'string')
 		{
@@ -1635,15 +1634,15 @@ var Init = function(elem_id, options, tickMS) {
 				items[i] = {};
 				items[i].file = options.tracks[i];
 			}	
-			that.tracks = new Gapless5FileList(items, 0, shuffleInit);
-			for (var i = 0; i < that.tracks.files().length ; i++)
-				that.addInitialTrack(that.tracks.files()[i]);
+			that.trk = new Gapless5FileList(items, 0, shuffleInit);
+			for (var i = 0; i < that.trk.files().length ; i++)
+				that.addInitialTrack(that.trk.files()[i]);
 		}
 		else if (typeof options.tracks[0] == 'object')
 		{
-			that.tracks = new Gapless5FileList(options.tracks, that.startingTrack, shuffleInit);
-			for (var i = 0; i < that.tracks.files().length ; i++)
-				that.addInitialTrack(that.tracks.files()[i]);
+			that.trk = new Gapless5FileList(options.tracks, that.startingTrack, shuffleInit);
+			for (var i = 0; i < that.trk.files().length ; i++)
+				that.addInitialTrack(that.trk.files()[i]);
 		}
 	}
 
@@ -1652,7 +1651,7 @@ var Init = function(elem_id, options, tickMS) {
 
 	// autostart if desired
 	var playOnLoad = (options != undefined) && ('playOnLoad' in options) && (options.playOnLoad == true);
-	if (playOnLoad && (that.tracks.current.length > 0))
+	if (playOnLoad && (that.trk.current.length > 0))
 	{
 		sources[index()].play();
 	}

--- a/gapless5.js
+++ b/gapless5.js
@@ -61,6 +61,9 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 	var audioFinished = false;
 	var endedCallback = null;
 
+	// request manager info
+	var clock = new Date().getTime();
+
 	this.uiDirty = false;
 	var that = this;
 	var parent = parentPlayer;
@@ -78,6 +81,12 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		state = newState;
 		queuedState = Gapless5State.None;
 	};
+
+	this.timer = function() {
+		var now = new Date().getTime();
+		var timerMs = now - clock;
+		return timerMs;
+	}
 
 	this.cancelRequest = function (isError) {
 		setState((isError == true) ? Gapless5State.Error : Gapless5State.None);

--- a/gapless5.js
+++ b/gapless5.js
@@ -144,7 +144,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		request = null;
 		buffer = inBuffer;
 		endpos = inBuffer.duration * 1000;
-		finishMS = startTime + endPos;
+		finishMS = startTime + endpos;
 		if (audio != null || !parent.useHTML5Audio)
 		{
 			loadMS = (new Date().getTime()) - initMS;
@@ -181,7 +181,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 
 		state = Gapless5State.Stop;
 		endpos = audio.duration * 1000;
-		finishMS = startTime + endPos;
+		finishMS = startTime + endpos;
 
 		if (queuedState == Gapless5State.Play)
 		{
@@ -409,12 +409,12 @@ var Gapless5RequestManager = function(parentPlayer) {
 	// PUBLIC METHODS
 	// Choose the effective policy in use. Some rules:
 	//    album: revert to "desktop" policy if used for shuffledPolicy
-        this.setPolicy(orderedPolicy, shuffledPolicy) {
+        this.setPolicy = function(orderedPolicy, shuffledPolicy) {
 	 	that.orderedPolicy = orderedPolicy;
 		that.shuffledPolicy = shuffledPolicy;
 	}
 
-	this.getPolicy() {
+	this.getPolicy = function() {
 		if (parent.tracks.shuffled() == true)
 		{
 			return shuffledPolicy;

--- a/gapless5.js
+++ b/gapless5.js
@@ -62,7 +62,8 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 	var endedCallback = null;
 
 	// request manager info
-	var clock = new Date().getTime();
+	var initMS = new Date().getTime();
+	var loadMS = null;
 
 	this.uiDirty = false;
 	var that = this;
@@ -84,8 +85,8 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 
 	this.timer = function() {
 		var now = new Date().getTime();
-		var timerMs = now - clock;
-		return timerMs;
+		var timerMS = now - initMS;
+		return timerMS;
 	}
 
 	this.cancelRequest = function (isError) {
@@ -119,6 +120,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		endpos = inBuffer.duration * 1000;
 		if (audio != null || !parent.useHTML5Audio)
 		{
+			loadMS = (new Date().getTime()) - initMS;
 			parent.dequeueNextLoad();
 		}
 
@@ -146,6 +148,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		if (state != Gapless5State.Loading) return;
 		if (buffer != null || !parent.useWebAudio)
 		{
+			loadMS = (new Date().getTime()) - initMS;
 			parent.dequeueNextLoad();
 		}
 
@@ -325,18 +328,14 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 
 
 // A RequestManager tracks all the available song objects and their states.
-// It sets timers and manages the downloading of new songs based on what's
-// most appropriate for the platform used.
-// You may also select your own policy from the following:
+// It manages the downloading of new songs based on what's most appropriate 
+// for the platform used.
+// You may also manually select a policy from the following:
 //	mobile: no more than 2 songs buffered ahead of current song
 //	desktop: no more than 5 songs buffered ahead of current song
 //	album: buffer songs ahead until the last song on the album
 //	oom: keep buffering songs (until you force an Out-Of-Memory error)
 var Gapless5RequestManager = function(orderedPolicy, shuffledPolicy) {
-
-	// TODO: List of things to support request manager that should be added
-	// to the Song object: Timers, State for errors/loading problems. The RM
-	// sets timer policies, but the timers themselves are in the Source obj.
 
 	// OBJECT STATE
 	// Each request manager item is an object containing the Gapless5Source,

--- a/gapless5.js
+++ b/gapless5.js
@@ -315,6 +315,48 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 }
 
 
+// A RequestManager tracks all the available song objects and their states.
+// It sets timers and manages the downloading of new songs based on what's
+// most appropriate for the platform used.
+// You may also select your own policy from the following:
+//	mobile: no more than 2 songs buffered ahead of current song
+//	desktop: no more than 5 songs buffered ahead of current song
+//	album: buffer songs ahead until the last song on the album
+//	oom: keep buffering songs (until you force an Out-Of-Memory error)
+var Gapless5RequestManager = function(orderedPolicy, shuffledPolicy) {
+
+	// TODO: List of things to support request manager that should be added
+	// to the Song object: Timers, State for errors/loading problems. The RM
+	// sets timer policies, but the timers themselves are in the Source obj.
+
+	// OBJECT STATE
+	// Each request manager item is an object containing the Gapless5Source,
+	// the loading/progress state, and other metadata
+	this.orderedPolicy = orderedPolicy;
+	this.shuffledPolicy = shuffledPolicy;
+	
+	// Stack of songs to load. TODO: if song is added to stack that already exists in
+	// the history, grab it from there instead of downloading it again
+	var stack = [];
+	var history = []; 
+
+	// PRIVATE METHODS
+	// Choose the effective policy in use. Some rules:
+	//    album: revert to "desktop" policy if used for shuffledPolicy
+        function effectivePolicy() {
+		return;
+	}
+
+	// PUBLIC METHODS
+	// Add a song to the request manager stack. Do this just after Method returns a Gapless5Source
+	// object, so it can be compatible with the new Gapless5Source statements.
+	this.register = function(song) {
+		return song;
+	}
+
+}
+
+
 // A Gapless5FileList "class". Processes an array of JSON song objects, taking 
 // the "file" members out to constitute the sources[] in the Gapless5 player
 var Gapless5FileList = function(inPlayList, inStartingTrack, inShuffle) {

--- a/gapless5.js
+++ b/gapless5.js
@@ -148,7 +148,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		if (audio != null || !parent.useHTML5Audio)
 		{
 			loadMS = (new Date().getTime()) - initMS;
-			parent.mgr.dequeueNextLoad(parent.mgr.sources);
+			parent.mgr.dequeueNextLoad();
 		}
 
 		if (queuedState == Gapless5State.Play && state == Gapless5State.Loading)
@@ -176,7 +176,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		if (buffer != null || !parent.useWebAudio)
 		{
 			loadMS = (new Date().getTime()) - initMS;
-			parent.mgr.dequeueNextLoad(parent.mgr.sources);
+			parent.mgr.dequeueNextLoad();
 		}
 
 		state = Gapless5State.Stop;
@@ -311,7 +311,7 @@ function Gapless5Source(parentPlayer, inContext, inOutputNode) {
 		audioPath = inAudioPath;
 		if (source || audio)
 		{
-			parent.mgr.dequeueNextLoad(parent.mgr.sources);
+			parent.mgr.dequeueNextLoad();
 			return;
 		}
 		if (state == Gapless5State.Loading)

--- a/gapless5.js
+++ b/gapless5.js
@@ -343,8 +343,9 @@ var Gapless5RequestManager = function(orderedPolicy, shuffledPolicy) {
 	this.orderedPolicy = orderedPolicy;
 	this.shuffledPolicy = shuffledPolicy;
 	
-	// Stack of songs to load. TODO: if song is added to stack that already exists in
-	// the history, grab it from there instead of downloading it again
+	// Stack of songs to load. 
+	// TODO: if song is added to stack that already exists in the history,
+	// grab it from there instead of downloading it again
 	var stack = [];
 	var history = []; 
 
@@ -356,8 +357,9 @@ var Gapless5RequestManager = function(orderedPolicy, shuffledPolicy) {
 	}
 
 	// PUBLIC METHODS
-	// Add a song to the request manager stack. Do this just after Method returns a Gapless5Source
-	// object, so it can be compatible with the new Gapless5Source statements.
+	// Add a song to the request manager stack. 
+	// Do this just after Method returns a Gapless5Source object, so it 
+	// can be compatible with the new Gapless5Source statements.
 	this.register = function(song) {
 		return song;
 	}


### PR DESCRIPTION
These are the basics of having a "request manager" object for implementing policies for song downloads, based on the requesting device. The goal is to eventually manage audioContext memory usage by juggling multiple audio contexts, and switching between them as necessary in thoughtful, gapless ways. This will be important for the "album-length jukebox" use-cases of Gapless.

It's mostly a refactor, with additional (currently-unused) Gapless5Source variables and methods/timers scattered about that anticipate RequestManager needs. The only current policy that exists was copied from the original dequeueNextLoad function, and is called the "oomPolicy" in honor of Gapless crashing my phones and old laptops. :) 

It appears to have behavior parity with the existing master branch. I tested against my jukebox, the synth-test suite, and a clone of the ZFP. Let me know if anything looks silly!