### PR TITLE
Fix use of nonexistent variable in getTrack

### DIFF
--- a/gapless5.js
+++ b/gapless5.js
@@ -1191,7 +1191,7 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
 
   this.getTracks = () => this.playlist.getTracks();
 
-  this.getTrack = () => this.currentSource() ? this.currentSource().audioPath : None;
+  this.getTrack = () => this.currentSource() ? this.currentSource().audioPath : '';
 
   this.findTrack = (path) => this.playlist.findTrack(path);
 


### PR DESCRIPTION
Got an error using `getTrack` because it tries to call a variable which does not exist. Unsure if this is the desired approach, but I thought it was best to replace with an empty string, since it would normally return a string, and that way checks like `getTrack().endsWith("cool.mp3")` don't break.