### PR TITLE
Clamp setVolume value

### DIFF
--- a/gapless5.js
+++ b/gapless5.js
@@ -1076,9 +1076,9 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
 
   // volume is normalized between 0 and 1
   this.setVolume = (volume) => {
-    this.volume = volume;
+    this.volume = Math.min(Math.max(volume, 0), 1);
     if (this.hasGUI) {
-      getElement('volume').value = scrubSize * volume;
+      getElement('volume').value = scrubSize * this.volume;
     }
   };
 


### PR DESCRIPTION
Prevents the volume value being set to something below 0 or above 1, which could cause errors. Makes the function safer than directly setting the `volume` property, particularly if doing math to set the volume, like making it fade in or out.