### PR TITLE
Patch: Fix Index Resetting on Removal, Fix bad `isShuffled` reference

### DIFF
--- a/gapless5.js
+++ b/gapless5.js
@@ -851,7 +851,7 @@ function Gapless5FileList(parentPlayer, parentLog, inShuffle, inLoadLimit = -1, 
     // we removed a track after current (current still points at the
     // same source).
 
-    if (this.isShuffled && !player.canShuffle()) {
+    if (this.isShuffled() && !player.canShuffle()) {
       this.setShuffle(false);
       player.uiDirty = true;
     }

--- a/gapless5.js
+++ b/gapless5.js
@@ -1372,6 +1372,7 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
       return;
     }
     const deletedPlaying = point === this.playlist.trackNumber;
+    const removedCurrentAtTail = deletedPlaying && point === this.playlist.numTracks() - 1;
 
     const { source: curSource } = this.playlist.getSourceIndexed(point);
     if (!curSource) {
@@ -1394,9 +1395,23 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
     // listeners that the current track silently changed, and resume
     // playback on the new current track if we were playing before.
     if (deletedPlaying && this.playlist.numTracks() > 0) {
+      // Removing the currently-playing track when it was the tail has
+      // special semantics:
+      //   - loop on:  wrap to start of playlist, resume playback
+      //   - loop off: clamp to new last, always pause
+      let shouldResume = wasPlaying;
+      if (removedCurrentAtTail) {
+        if (this.loop) {
+          this.playlist.trackNumber = 0;
+          this.playlist.updateLoading();
+        } else {
+          shouldResume = false;
+        }
+      }
+
       const newSource = this.currentSource();
       this.onnext(deletedPath, newSource ? newSource.audioPath : '');
-      if (wasPlaying) {
+      if (shouldResume) {
         this.play();
       }
     }

--- a/gapless5.js
+++ b/gapless5.js
@@ -833,20 +833,32 @@ function Gapless5FileList(parentPlayer, parentLog, inShuffle, inLoadLimit = -1, 
       }
     }
 
-    // Stay at the same song index, unless trackNumber is after the
-    // removed index, or was removed at the edge of the list
-    if (this.trackNumber > 0 &&
-      ((index < this.trackNumber) || (index >= this.numTracks() - 2))) {
+    const newLength = this.numTracks();
+    if (newLength === 0) {
+      this.trackNumber = -1;
+    } else if (index < this.trackNumber) {
+      // Removed a track before the current one — current shifts left.
       this.trackNumber = this.trackNumber - 1;
       log.debug(`Decrementing track number to ${this.trackNumber}`);
+    } else if (index === this.trackNumber && this.trackNumber >= newLength) {
+      // Removed the current track AND it was the last in the list —
+      // clamp to the new last track.
+      this.trackNumber = newLength - 1;
+      log.debug(`Clamping track number to ${this.trackNumber}`);
     }
+    // Otherwise trackNumber is unchanged: either the next track slid
+    // into the removed slot (auto-advance when removing current), or
+    // we removed a track after current (current still points at the
+    // same source).
 
     if (this.isShuffled && !player.canShuffle()) {
       this.setShuffle(false);
       player.uiDirty = true;
     }
 
-    this.updateLoading();
+    if (newLength > 0) {
+      this.updateLoading();
+    }
   };
 
   // process inputs from constructor
@@ -1376,11 +1388,12 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
 
     this.playlist.remove(point);
 
-    if (deletedPlaying) {
-      this.next(); // Don't stop after a delete
-      if (wasPlaying) {
-        this.play();
-      }
+    // playlist.remove() already advanced trackNumber to the track that
+    // slid into this slot (or the new last track / -1 if empty), so we
+    // just need to resume playback on the new current track if we were
+    // playing before removal.
+    if (deletedPlaying && wasPlaying && this.playlist.numTracks() > 0) {
+      this.play();
     }
 
     this.uiDirty = true;

--- a/gapless5.js
+++ b/gapless5.js
@@ -1377,6 +1377,7 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
     if (!curSource) {
       return;
     }
+    const deletedPath = curSource.audioPath;
     let wasPlaying = false;
 
     if (curSource.state === Gapless5State.Loading) {
@@ -1389,11 +1390,15 @@ function Gapless5(options = {}, deprecated = {}) { // eslint-disable-line no-unu
     this.playlist.remove(point);
 
     // playlist.remove() already advanced trackNumber to the track that
-    // slid into this slot (or the new last track / -1 if empty), so we
-    // just need to resume playback on the new current track if we were
-    // playing before removal.
-    if (deletedPlaying && wasPlaying && this.playlist.numTracks() > 0) {
-      this.play();
+    // slid into this slot (or the new last track / -1 if empty). Notify
+    // listeners that the current track silently changed, and resume
+    // playback on the new current track if we were playing before.
+    if (deletedPlaying && this.playlist.numTracks() > 0) {
+      const newSource = this.currentSource();
+      this.onnext(deletedPath, newSource ? newSource.audioPath : '');
+      if (wasPlaying) {
+        this.play();
+      }
     }
 
     this.uiDirty = true;

--- a/gapless5.test.js
+++ b/gapless5.test.js
@@ -154,91 +154,91 @@ describe('Gapless-5 object with tracklist', () => {
   });
 
   it('regression: maintains correct index when removing tracks that come after the currently playing track', () => {
-    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
-    const player = new Gapless5({
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3' ];
+    const testPlayer = new Gapless5({
       ...INIT_OPTIONS,
       tracks: testTracks,
     });
 
     // Verify initial state
-    expect(player.getIndex()).toBe(0);
-    expect(player.getTracks()).toStrictEqual(testTracks);
+    expect(testPlayer.getIndex()).toBe(0);
+    expect(testPlayer.getTracks()).toStrictEqual(testTracks);
 
     // Move to track 1
-    player.gotoTrack(1);
-    expect(player.getIndex()).toBe(1);
+    testPlayer.gotoTrack(1);
+    expect(testPlayer.getIndex()).toBe(1);
 
     // Remove track at index 2
-    player.removeTrack(2);
+    testPlayer.removeTrack(2);
 
     // Check index is still 1 and track list is updated
-    expect(player.getIndex()).toBe(1);
-    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track2.mp3']);
+    expect(testPlayer.getIndex()).toBe(1);
+    expect(testPlayer.getTracks()).toStrictEqual([ 'track1.mp3', 'track2.mp3' ]);
   });
 
   it('regression: maintains correct index when removing the currently playing track', () => {
-    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
-    const player = new Gapless5({
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3' ];
+    const testPlayer = new Gapless5({
       ...INIT_OPTIONS,
       tracks: testTracks,
     });
 
     // Verify initial state
-    expect(player.getIndex()).toBe(0);
-    expect(player.getTracks()).toStrictEqual(testTracks);
+    expect(testPlayer.getIndex()).toBe(0);
+    expect(testPlayer.getTracks()).toStrictEqual(testTracks);
 
     // Move to track 1
-    player.gotoTrack(1);
-    expect(player.getIndex()).toBe(1);
-    player.play();
+    testPlayer.gotoTrack(1);
+    expect(testPlayer.getIndex()).toBe(1);
+    testPlayer.play();
 
     // Remove the currently playing track
-    player.removeTrack(1);
+    testPlayer.removeTrack(1);
 
     // Check index is still 1 and track list is updated, therefore we move to the next available track
-    expect(player.getIndex()).toBe(1);
-    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track3.mp3']);
+    expect(testPlayer.getIndex()).toBe(1);
+    expect(testPlayer.getTracks()).toStrictEqual([ 'track1.mp3', 'track3.mp3' ]);
 
-    player.play();
+    testPlayer.play();
 
     // Remove the currently playing track
-    player.removeTrack(1);
+    testPlayer.removeTrack(1);
 
     // Check index is still 0 and track list is updated, therefore we move to the next available track
-    expect(player.getIndex()).toBe(0);
-    expect(player.getTracks()).toStrictEqual(['track1.mp3']);
+    expect(testPlayer.getIndex()).toBe(0);
+    expect(testPlayer.getTracks()).toStrictEqual([ 'track1.mp3' ]);
 
-    player.play();
+    testPlayer.play();
 
     // Remove the only remaining track — list is empty, index resets to -1
-    player.removeTrack(0);
-    expect(player.getIndex()).toBe(-1);
-    expect(player.getTracks()).toStrictEqual([]);
+    testPlayer.removeTrack(0);
+    expect(testPlayer.getIndex()).toBe(-1);
+    expect(testPlayer.getTracks()).toStrictEqual([]);
   });
 
   it('regression: removing a track does not wipe shuffledIndices', () => {
-    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3', 'track4.mp3'];
-    const player = new Gapless5({
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3', 'track4.mp3' ];
+    const testPlayer = new Gapless5({
       ...INIT_OPTIONS,
       tracks: testTracks,
     });
 
-    player.shuffle();
-    player.next(); // commit the shuffle
-    expect(player.isShuffled()).toBe(true);
-    expect(player.playlist.shuffledIndices.length).toBe(testTracks.length);
+    testPlayer.shuffle();
+    testPlayer.next(); // commit the shuffle
+    expect(testPlayer.isShuffled()).toBe(true);
+    expect(testPlayer.playlist.shuffledIndices.length).toBe(testTracks.length);
 
-    player.removeTrack(0);
+    testPlayer.removeTrack(0);
 
     // Shuffle order should still be intact (one fewer entry, still shuffled)
-    expect(player.isShuffled()).toBe(true);
-    expect(player.playlist.shuffledIndices.length).toBe(testTracks.length - 1);
-    expect(player.getTracks().length).toBe(testTracks.length - 1);
+    expect(testPlayer.isShuffled()).toBe(true);
+    expect(testPlayer.playlist.shuffledIndices.length).toBe(testTracks.length - 1);
+    expect(testPlayer.getTracks().length).toBe(testTracks.length - 1);
   });
 
   it('regression: removing currently-playing track repeatedly until empty does not crash', () => {
-    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
-    const player = new Gapless5({
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3' ];
+    const testPlayer = new Gapless5({
       ...INIT_OPTIONS,
       tracks: testTracks,
     });
@@ -246,67 +246,66 @@ describe('Gapless-5 object with tracklist', () => {
     // Walk the list down to zero by always removing the current track
     // This reproduces a crash in the pre-PR code where updateLoading()
     // would dereference an undefined source after the list went empty.
-    while (player.getTracks().length > 0) {
-      player.removeTrack(player.getIndex());
+    while (testPlayer.getTracks().length > 0) {
+      testPlayer.removeTrack(testPlayer.getIndex());
     }
-    expect(player.getTracks()).toStrictEqual([]);
-    expect(player.getIndex()).toBe(-1);
+    expect(testPlayer.getTracks()).toStrictEqual([]);
+    expect(testPlayer.getIndex()).toBe(-1);
   });
 
   it('regression: removing current-at-tail with loop=true wraps to start and resumes', () => {
-    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
-    const player = new Gapless5({
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3' ];
+    const testPlayer = new Gapless5({
       ...INIT_OPTIONS,
       tracks: testTracks,
       loop: true,
     });
 
-    player.gotoTrack(2);
-    expect(player.getIndex()).toBe(2);
+    testPlayer.gotoTrack(2);
+    expect(testPlayer.getIndex()).toBe(2);
 
     // Force the tail source to report as playing so removeTrack takes the
     // wasPlaying branch (the mock audio env never transitions real state).
-    player.playlist.sources[2].inPlayState = () => true;
+    testPlayer.playlist.sources[2].inPlayState = () => true;
 
-    player.onnext = jest.fn();
-    player.onplayrequest = jest.fn();
+    testPlayer.onnext = jest.fn();
+    testPlayer.onplayrequest = jest.fn();
 
-    player.removeTrack(2);
+    testPlayer.removeTrack(2);
 
-    expect(player.getIndex()).toBe(0);
-    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track2.mp3']);
-    expect(player.onnext).toHaveBeenCalledWith('track3.mp3', 'track1.mp3');
-    expect(player.onplayrequest).toHaveBeenCalledTimes(1);
-    expect(player.onplayrequest).toHaveBeenCalledWith('track1.mp3');
+    expect(testPlayer.getIndex()).toBe(0);
+    expect(testPlayer.getTracks()).toStrictEqual([ 'track1.mp3', 'track2.mp3' ]);
+    expect(testPlayer.onnext).toHaveBeenCalledWith('track3.mp3', 'track1.mp3');
+    expect(testPlayer.onplayrequest).toHaveBeenCalledTimes(1);
+    expect(testPlayer.onplayrequest).toHaveBeenCalledWith('track1.mp3');
   });
 
   it('regression: removing current-at-tail with loop=false clamps and always pauses', () => {
-    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
-    const player = new Gapless5({
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3' ];
+    const testPlayer = new Gapless5({
       ...INIT_OPTIONS,
       tracks: testTracks,
       loop: false,
     });
 
-    player.gotoTrack(2);
-    expect(player.getIndex()).toBe(2);
+    testPlayer.gotoTrack(2);
+    expect(testPlayer.getIndex()).toBe(2);
 
     // Force the tail source to report as playing so removeTrack takes the
     // wasPlaying branch — this is the scenario where the old code would
     // have auto-resumed on the clamped-to-last track.
-    player.playlist.sources[2].inPlayState = () => true;
+    testPlayer.playlist.sources[2].inPlayState = () => true;
 
-    player.onnext = jest.fn();
-    player.onplayrequest = jest.fn();
+    testPlayer.onnext = jest.fn();
+    testPlayer.onplayrequest = jest.fn();
 
-    player.removeTrack(2);
+    testPlayer.removeTrack(2);
 
-    expect(player.getIndex()).toBe(1);
-    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track2.mp3']);
-    expect(player.onnext).toHaveBeenCalledWith('track3.mp3', 'track2.mp3');
-    expect(player.onplayrequest).not.toHaveBeenCalled();
+    expect(testPlayer.getIndex()).toBe(1);
+    expect(testPlayer.getTracks()).toStrictEqual([ 'track1.mp3', 'track2.mp3' ]);
+    expect(testPlayer.onnext).toHaveBeenCalledWith('track3.mp3', 'track2.mp3');
+    expect(testPlayer.onplayrequest).not.toHaveBeenCalled();
   });
-
 });
 
 describe('Gapless-5 object with load limit', () => {

--- a/gapless5.test.js
+++ b/gapless5.test.js
@@ -306,6 +306,25 @@ describe('Gapless-5 object with tracklist', () => {
     expect(testPlayer.onnext).toHaveBeenCalledWith('track3.mp3', 'track2.mp3');
     expect(testPlayer.onplayrequest).not.toHaveBeenCalled();
   });
+
+  it('regression: removing a track does not spuriously disable shuffle when never shuffled', () => {
+    const testTracks = [ 'track1.mp3', 'track2.mp3', 'track3.mp3' ];
+    const testPlayer = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+    });
+
+    expect(testPlayer.isShuffled()).toBe(false);
+    const setShuffleSpy = jest.spyOn(testPlayer.playlist, 'setShuffle');
+
+    // Drop to 2 tracks — previously tripped the shuffle-disable path
+    // because `this.isShuffled` (a function reference) was always truthy.
+    testPlayer.removeTrack(0);
+
+    expect(testPlayer.isShuffled()).toBe(false);
+    expect(setShuffleSpy).not.toHaveBeenCalled();
+    setShuffleSpy.mockRestore();
+  });
 });
 
 describe('Gapless-5 object with load limit', () => {

--- a/gapless5.test.js
+++ b/gapless5.test.js
@@ -152,6 +152,106 @@ describe('Gapless-5 object with tracklist', () => {
     player.stop();
     expect(player.onstop).toHaveBeenCalledWith(TRACKS[0]);
   });
+
+  it('regression: maintains correct index when removing tracks that come after the currently playing track', () => {
+    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
+    const player = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+    });
+
+    // Verify initial state
+    expect(player.getIndex()).toBe(0);
+    expect(player.getTracks()).toStrictEqual(testTracks);
+
+    // Move to track 1
+    player.gotoTrack(1);
+    expect(player.getIndex()).toBe(1);
+
+    // Remove track at index 2
+    player.removeTrack(2);
+
+    // Check index is still 1 and track list is updated
+    expect(player.getIndex()).toBe(1);
+    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track2.mp3']);
+  });
+
+  it('regression: maintains correct index when removing the currently playing track', () => {
+    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
+    const player = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+    });
+
+    // Verify initial state
+    expect(player.getIndex()).toBe(0);
+    expect(player.getTracks()).toStrictEqual(testTracks);
+
+    // Move to track 1
+    player.gotoTrack(1);
+    expect(player.getIndex()).toBe(1);
+    player.play();
+
+    // Remove the currently playing track
+    player.removeTrack(1);
+
+    // Check index is still 1 and track list is updated, therefore we move to the next available track
+    expect(player.getIndex()).toBe(1);
+    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track3.mp3']);
+
+    player.play();
+
+    // Remove the currently playing track
+    player.removeTrack(1);
+
+    // Check index is still 0 and track list is updated, therefore we move to the next available track
+    expect(player.getIndex()).toBe(0);
+    expect(player.getTracks()).toStrictEqual(['track1.mp3']);
+
+    player.play();
+
+    // Remove the only remaining track — list is empty, index resets to -1
+    player.removeTrack(0);
+    expect(player.getIndex()).toBe(-1);
+    expect(player.getTracks()).toStrictEqual([]);
+  });
+
+  it('regression: removing a track does not wipe shuffledIndices', () => {
+    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3', 'track4.mp3'];
+    const player = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+    });
+
+    player.shuffle();
+    player.next(); // commit the shuffle
+    expect(player.isShuffled()).toBe(true);
+    expect(player.playlist.shuffledIndices.length).toBe(testTracks.length);
+
+    player.removeTrack(0);
+
+    // Shuffle order should still be intact (one fewer entry, still shuffled)
+    expect(player.isShuffled()).toBe(true);
+    expect(player.playlist.shuffledIndices.length).toBe(testTracks.length - 1);
+    expect(player.getTracks().length).toBe(testTracks.length - 1);
+  });
+
+  it('regression: removing currently-playing track repeatedly until empty does not crash', () => {
+    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
+    const player = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+    });
+
+    // Walk the list down to zero by always removing the current track
+    // This reproduces a crash in the pre-PR code where updateLoading()
+    // would dereference an undefined source after the list went empty.
+    while (player.getTracks().length > 0) {
+      player.removeTrack(player.getIndex());
+    }
+    expect(player.getTracks()).toStrictEqual([]);
+    expect(player.getIndex()).toBe(-1);
+  });
 });
 
 describe('Gapless-5 object with load limit', () => {
@@ -179,3 +279,5 @@ describe('Gapless-5 object with load limit', () => {
     expect(loadedTracks.size).toBe(0);
   });
 });
+
+

--- a/gapless5.test.js
+++ b/gapless5.test.js
@@ -279,5 +279,3 @@ describe('Gapless-5 object with load limit', () => {
     expect(loadedTracks.size).toBe(0);
   });
 });
-
-

--- a/gapless5.test.js
+++ b/gapless5.test.js
@@ -252,6 +252,61 @@ describe('Gapless-5 object with tracklist', () => {
     expect(player.getTracks()).toStrictEqual([]);
     expect(player.getIndex()).toBe(-1);
   });
+
+  it('regression: removing current-at-tail with loop=true wraps to start and resumes', () => {
+    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
+    const player = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+      loop: true,
+    });
+
+    player.gotoTrack(2);
+    expect(player.getIndex()).toBe(2);
+
+    // Force the tail source to report as playing so removeTrack takes the
+    // wasPlaying branch (the mock audio env never transitions real state).
+    player.playlist.sources[2].inPlayState = () => true;
+
+    player.onnext = jest.fn();
+    player.onplayrequest = jest.fn();
+
+    player.removeTrack(2);
+
+    expect(player.getIndex()).toBe(0);
+    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track2.mp3']);
+    expect(player.onnext).toHaveBeenCalledWith('track3.mp3', 'track1.mp3');
+    expect(player.onplayrequest).toHaveBeenCalledTimes(1);
+    expect(player.onplayrequest).toHaveBeenCalledWith('track1.mp3');
+  });
+
+  it('regression: removing current-at-tail with loop=false clamps and always pauses', () => {
+    const testTracks = ['track1.mp3', 'track2.mp3', 'track3.mp3'];
+    const player = new Gapless5({
+      ...INIT_OPTIONS,
+      tracks: testTracks,
+      loop: false,
+    });
+
+    player.gotoTrack(2);
+    expect(player.getIndex()).toBe(2);
+
+    // Force the tail source to report as playing so removeTrack takes the
+    // wasPlaying branch — this is the scenario where the old code would
+    // have auto-resumed on the clamped-to-last track.
+    player.playlist.sources[2].inPlayState = () => true;
+
+    player.onnext = jest.fn();
+    player.onplayrequest = jest.fn();
+
+    player.removeTrack(2);
+
+    expect(player.getIndex()).toBe(1);
+    expect(player.getTracks()).toStrictEqual(['track1.mp3', 'track2.mp3']);
+    expect(player.onnext).toHaveBeenCalledWith('track3.mp3', 'track2.mp3');
+    expect(player.onplayrequest).not.toHaveBeenCalled();
+  });
+
 });
 
 describe('Gapless-5 object with load limit', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@regosen/gapless-5",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A gapless JavaScript audio player for HTML5",
   "main": "gapless5.js",
   "style": "gapless5.css",


### PR DESCRIPTION
## This PR

Fixes a bug causing the index/trackNumber of the currently playing song to be incorrect after calling `removeTrack`.

Found while developing on my music app *hihat*:
* https://github.com/johnnyshankman/hihat/pull/41

## Scope

- **`removeTrack(index)` no longer resets `trackNumber` to 0** when removing any track in the tail half of the list. Root cause was an over-decrement in `Gapless5FileList.remove` whenever `index >= numTracks - 2`, regardless of whether the removed track was before or after the current one.
- **Removing the currently-playing track** now correctly auto-advances to the track that slid into the removed slot (or clamps to the new last track if the current was the tail, or sets `trackNumber` to `-1` if the list is now empty). Playback resumes on the new current if it was playing before. `onnext` fires so UI listeners can repaint.
- **Removing the currently-playing track repeatedly until empty** no longer crashes in `updateLoading()` on an undefined source. `updateLoading()` is now skipped when the list is empty.
- **`shuffledIndices` is preserved** across removes (prior iteration of this PR wiped it — fixed per review feedback).

## Reproduction of the original issue

1. Load a track list of three songs.
2. `getIndex()` returns `0`.
3. `gotoTrack(1)` — `getIndex()` returns `1`.
4. `removeTrack(2)` — removes the tail.
5. Before this PR, `getIndex()` returned `0` instead of `1`, causing the player to pause and return wrong track info.

## Note on `replaceTrack`

`replaceTrack` defers to `removeTrack` + `insertTrack`, and this PR does not attempt to fix `replaceTrack` behavior when replacing the currently-playing track — the removeTrack auto-advance + insertTrack re-shift can leave `trackNumber` pointing at the wrong source in that specific case. That's a pre-existing interaction issue worth a separate follow-up PR.

## QA

- New regression tests cover:
  - Removing a track after the currently playing track preserves the index.
  - Removing the currently playing track auto-advances (including walking down to empty).
  - Removing a track keeps `shuffledIndices` intact.
  - Removing the current track repeatedly until empty does not crash.
- All existing tests still pass.

<img width="878" height="389" alt="Screenshot 2026-04-13 at 6 14 01 PM" src="https://github.com/user-attachments/assets/b106adad-95f2-45f1-b570-9e92642c1503" />