### PR TITLE
Add eslint as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/regosen/Gapless-5#readme",
   "devDependencies": {
     "@types/node": "^20.10.4",
+    "eslint": "^8.57.1",
     "jest": "^27.3.1",
     "typescript": "^5.3.3"
   }


### PR DESCRIPTION
## Problem

`npm run lint` fails out of the box — `eslint` isn't declared as a dependency.

## Fix

Add `eslint` to `devDependencies`, pinned to `^8.57.1`.

`.eslintrc.js` is legacy config format so we pin to latest v8. ESLint v9+ requires flat config (`eslint.config.js`), which would be a larger change.

## Notes

- Dev tooling only — no version bump needed.
- Verified with a clean `npm install` followed by `npm run lint` (exits 0).